### PR TITLE
Update profile content, add Visteon role and logo, and refine hero/resume behavior

### DIFF
--- a/components/sections/AboutSection.tsx
+++ b/components/sections/AboutSection.tsx
@@ -23,7 +23,7 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
   }, [inView, setActiveSection]);
 
   const stats = [
-    { number: '2+', label: 'Years Experience', icon: Target },
+    { number: '3+', label: 'Years Experience', icon: Target },
     { number: '1500+', label: 'Problems Solved', icon: Code },
     { number: '6', label: 'Certifications', icon: Award },
     { number: '5+', label: 'Team Collaborations', icon: Users }
@@ -33,17 +33,17 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
     {
       icon: Code,
       title: 'AI-Powered Systems',
-      description: 'Designing and implementing modular, multi-agent RAG solutions and scalable data pipelines using Python, Spark, and cloud-native platforms.'
+      description: 'Designing production-grade Generative AI systems, multi-agent workflows, and enterprise automation platforms that deliver measurable business impact.'
     },
     {
       icon: Brain,
-      title: 'Accessible UI & Frontend',
-      description: 'Developing dynamic, accessible Angular-based UIs, leading accessibility efforts for WCAG/ADA compliance, and building custom components.'
+      title: 'Backend & AI Architecture',
+      description: 'Building resilient FastAPI and Python services with dependency injection, robust observability, and scalable API orchestration for enterprise workloads.'
     },
     {
       icon: Cloud,
       title: 'Cloud & Data Engineering',
-      description: 'Building secure, distributed, and high-availability platforms on Azure, SQL Lakehouse, and integrating with Power BI and vector databases.'
+      description: 'Developing scalable data and CV-powered automation solutions across SQL Server/Oracle ecosystems, document pipelines, and cloud-native services.'
     }
   ];
 
@@ -86,7 +86,7 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.2 }}
               >
-                I&apos;m Satyam Pandey, a Software Engineer with 2 years of experience specializing in building scalable applications and AI-powered systems. My passion lies in crafting cloud-native platforms that are both secure and accessible, designed to thrive in distributed environments.
+                I&apos;m Satyam Pandey, a Generative AI Engineer focused on building production-grade AI systems that drive measurable business impact.
               </motion.p>
 
               <motion.p
@@ -95,7 +95,7 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.25 }}
               >
-                My expertise spans full-stack development, from creating dynamic, Angular-based UI features and ensuring WCAG/ADA compliance, to architecting robust backend services. I have a strong track record in data engineering with Python and Spark, and a particular focus on designing and implementing advanced AI solutions, including multi-agent RAG frameworks and AI-powered data agent solutions.
+                At Visteon Corporation, I architect and deploy end-to-end AI and automation solutions, including a full-stack report automation platform that reduced processing time from 8 hours to under 2 minutes, and a computer vision-powered logo replacement system that improved document processing productivity by 90%+.
               </motion.p>
 
               <motion.p
@@ -104,7 +104,7 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.3 }}
               >
-                I&apos;m driven by a desire to optimize data workflows, enhance system performance, and implement Responsible AI principles. My commitment to excellence is reflected in my competitive programming achievements and certifications, including Microsoft Certified Azure AI Engineer Associate and Databricks Certified Data Engineer Associate.
+                Previously at MAQ Software, I led large-scale AI initiatives spanning RAG-based chatbots (serving 80K+ users), multi-agent analytics frameworks, scalable data pipelines, and cloud-native deployments across multiple regions. My work emphasizes scalability, Responsible AI, and enterprise reliability.
               </motion.p>
 
               <motion.p
@@ -113,7 +113,7 @@ export default function AboutSection({ setActiveSection }: AboutSectionProps) {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.35 }}
               >
-                Explore my projects to see how I translate complex challenges into innovative and impactful solutions.
+                I specialize in Generative AI, multi-agent systems, backend architecture (FastAPI/Python), computer vision, and scalable data platforms — building solutions that move from concept to high-impact production systems.
               </motion.p>
             </div>
 

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -6,7 +6,6 @@ import { useInView } from 'react-intersection-observer';
 import { Download, Linkedin } from 'lucide-react';
 import { SiGithub, SiX } from 'react-icons/si';
 import { Button } from '@/components/ui/button';
-import { getAssetPath } from '@/lib/assetUtils';
 
 interface HeroSectionProps {
   setActiveSection: (section: string) => void;
@@ -23,7 +22,7 @@ export default function HeroSection({ setActiveSection }: HeroSectionProps) {
   const [isDeleting, setIsDeleting] = useState(false);
 
   const roles = useMemo(() => [
-    'Software Engineer II @ MAQ Software',
+    'Generative AI Engineer @ Visteon',
     'AI & Data Engineering Specialist',
     'Angular & Python Developer',
     'Cloud-Native Platform Builder',
@@ -62,7 +61,7 @@ export default function HeroSection({ setActiveSection }: HeroSectionProps) {
     'Python', 'C#', 'C++', 'Java', 'SQL', 'JavaScript',
     'Angular', 'React', 'FastAPI', 'Spark', 'Semantic Kernel', 'Syncfusion',
     'Docker', 'CI/CD', 'Databricks', 'Snowflake', 'SSIS', 'Git',
-    'Azure', 'SQL Lakehouse', 'Vector DBs', 'Cloud AI Services', 'SQL Server'
+    'Azure', 'SQL Lakehouse', 'Vector DBs', 'Cloud AI Services', 'SQL Server', 'Oracle', 'OpenCV', 'YOLO', 'Power Automate'
   ];
 
   const socialLinks = [
@@ -73,12 +72,7 @@ export default function HeroSection({ setActiveSection }: HeroSectionProps) {
 
   // Function to handle resume download
   const handleResumeDownload = () => {
-    const link = document.createElement('a');
-    link.href = getAssetPath('/Satyam_Pandey_Resume.pdf');
-    link.download = 'Satyam_Pandey_Resume.pdf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    window.open('https://drive.google.com/file/d/1OSpUxIh-7DBSt_-qf55PVmgVuL0-rizj/view?usp=drivesdk', '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/components/sections/TimelineSection.tsx
+++ b/components/sections/TimelineSection.tsx
@@ -33,10 +33,28 @@ export default function TimelineSection({ setActiveSection }: TimelineSectionPro
   const experiences = [
     {
       id: 1,
+      title: 'Generative AI Engineer',
+      company: 'Visteon Corporation',
+      location: 'Pune, Maharashtra, India (Hybrid)',
+      period: 'Sep 2025 – Present',
+      type: 'Work',
+      description: 'Architecting and deploying production-grade AI automation systems, including full-stack report automation and computer-vision-powered document modernization workflows.',
+      achievements: [
+        'Reduced report generation from 8 hours to under 2 minutes (~240x) with a React + FastAPI automation platform',
+        'Built scalable APIs for log/CSV ingestion, analytics visuals, DOCX auto-fill, and audit logging',
+        'Created a Power Automate + FastAPI workflow to replace legacy logos in DOCX, PPTX, and PDFs while preserving structure',
+        'Trained a custom YOLO model for layout-safe PDF logo replacement, improving document processing productivity by 90%+'
+      ],
+      technologies: ['React', 'FastAPI', 'Python', 'SQL Server', 'Oracle', 'Power Automate', 'OpenCV', 'YOLO'],
+      logo: getAssetPath('/visteon_logo.svg'),
+      logoAlt: 'Visteon Corporation'
+    },
+    {
+      id: 2,
       title: 'Software Engineer II',
       company: 'MAQ Software',
       location: 'Noida, Uttar Pradesh, India',
-      period: 'Apr 2025 – Present',
+      period: 'Apr 2025 – Sep 2025',
       type: 'Work',
       description: 'Developed Angular-based UI features, led accessibility efforts, and architected AI-powered data agent solutions integrated with SQL Lakehouse and Power BI.',
       achievements: [
@@ -50,7 +68,7 @@ export default function TimelineSection({ setActiveSection }: TimelineSectionPro
       logoAlt: 'MAQ Software'
     },
     {
-      id: 2,
+      id: 3,
       title: 'Software Engineer I',
       company: 'MAQ Software',
       location: 'Noida, Uttar Pradesh, India',
@@ -68,7 +86,7 @@ export default function TimelineSection({ setActiveSection }: TimelineSectionPro
       logoAlt: 'MAQ Software'
     },
     {
-      id: 3,
+      id: 4,
       title: 'Associate Software Engineer',
       company: 'MAQ Software',
       location: 'Noida, Uttar Pradesh, India',
@@ -86,7 +104,7 @@ export default function TimelineSection({ setActiveSection }: TimelineSectionPro
       logoAlt: 'MAQ Software'
     },
     {
-      id: 4,
+      id: 5,
       title: 'B.Tech (IT)',
       company: 'IIIT Bhubaneswar',
       location: 'Bhubaneswar, Odisha, India',

--- a/public/visteon_logo.svg
+++ b/public/visteon_logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240" role="img" aria-label="Visteon logo">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#005a7a"/>
+      <stop offset="100%" stop-color="#002a56"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="0" fill="url(#bg)"/>
+  <path fill="#ffffff" d="M48 58h42l31 56 30-56h42l-72 124h-1z"/>
+  <text x="196" y="46" fill="#ffffff" font-size="16" font-family="Arial, Helvetica, sans-serif" font-weight="700">®</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Refresh personal branding to reflect Generative AI focus and updated work history.
- Add recent role at Visteon with supporting assets to show new production AI deliverables.
- Improve hero section roles, tech stack, and resume download behavior to use an external link.

### Description
- Updated `AboutSection.tsx` copy, refined focus area descriptions, and bumped the experience stat from `2+` to `3+`.
- Modified `HeroSection.tsx` to replace the old role with `Generative AI Engineer @ Visteon`, extend the `techStack`, and replace the resume download via `getAssetPath` with an external Drive link; removed the unused `getAssetPath` import from this file.
- Extended `TimelineSection.tsx` to add a new `Generative AI Engineer` entry for Visteon with achievements, technologies, and `logo` pointing to a new asset, and shifted other timeline entries' IDs and periods accordingly.
- Added a new `public/visteon_logo.svg` asset included for the timeline and adjusted timeline data to reference it.

### Testing
- Ran a production build with `npm run build` which completed successfully.
- Ran linting with `npm run lint` and no lint errors were reported.
- Ran the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f25718d8c832faddc5aba24839716)